### PR TITLE
Add new metadata fields

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,8 +53,9 @@ class _MyAppState extends State<MyApp> {
               onPressed: () async {
                 Tag tag = Tag(
                     title: "Title",
-                    artist: "Artist",
+                    trackArtist: "Track Artist",
                     album: "Album",
+                    albumArtist: "AlbumArtist",
                     genre: "Genre",
                     year: 2000,
                     trackNumber: 1,
@@ -74,8 +75,9 @@ class _MyAppState extends State<MyApp> {
               onPressed: () async {
                 Tag? tag = await AudioTags.read(path);
                 String? title = tag?.title;
-                String? artist = tag?.artist;
+                String? trackArtist = tag?.trackArtist;
                 String? album = tag?.album;
+                String? albumArtist = tag?.albumArtist;
                 String? genre = tag?.genre;
                 int? year = tag?.year;
                 int? trackNumber = tag?.trackNumber;
@@ -84,8 +86,9 @@ class _MyAppState extends State<MyApp> {
                 List<Picture>? pictures = tag?.pictures;
 
                 debugPrint("Title: $title");
-                debugPrint("Artist: $artist");
+                debugPrint("Track Artist: $trackArtist");
                 debugPrint("Album: $album");
+                debugPrint("Album Artist: $albumArtist");
                 debugPrint("Genre: $genre");
                 debugPrint("Year: ${year.toString()}");
                 debugPrint("Track Number: ${trackNumber.toString()}");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,6 +60,8 @@ class _MyAppState extends State<MyApp> {
                     year: 2000,
                     trackNumber: 1,
                     trackTotal: 2,
+                    discNumber: 1,
+                    discTotal: 3,
                     pictures: [
                       Picture(
                           bytes: Uint8List.fromList([0, 0, 0, 0]),
@@ -82,6 +84,8 @@ class _MyAppState extends State<MyApp> {
                 int? year = tag?.year;
                 int? trackNumber = tag?.trackNumber;
                 int? trackTotal = tag?.trackTotal;
+                int? discNumber = tag?.discNumber;
+                int? discTotal = tag?.discTotal;
                 int? duration = tag?.duration;
                 List<Picture>? pictures = tag?.pictures;
 
@@ -93,6 +97,8 @@ class _MyAppState extends State<MyApp> {
                 debugPrint("Year: ${year.toString()}");
                 debugPrint("Track Number: ${trackNumber.toString()}");
                 debugPrint("Track Total: ${trackTotal.toString()}");
+                debugPrint("Disc Number: ${discNumber.toString()}");
+                debugPrint("Disc Total: ${discTotal.toString()}");
                 debugPrint("Duration: ${duration.toString()}");
                 debugPrint("Pictures: $pictures");
               },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -55,7 +55,7 @@ class _MyAppState extends State<MyApp> {
                     title: "Title",
                     trackArtist: "Track Artist",
                     album: "Album",
-                    albumArtist: "AlbumArtist",
+                    albumArtist: "Album Artist",
                     genre: "Genre",
                     year: 2000,
                     trackNumber: 1,

--- a/ios/Classes/bridge_generated.h
+++ b/ios/Classes/bridge_generated.h
@@ -27,8 +27,9 @@ typedef struct wire_list_picture {
 
 typedef struct wire_Tag {
   struct wire_uint_8_list *title;
-  struct wire_uint_8_list *artist;
+  struct wire_uint_8_list *track_artist;
   struct wire_uint_8_list *album;
+  struct wire_uint_8_list *album_artist;
   uint32_t *year;
   struct wire_uint_8_list *genre;
   uint32_t *track_number;

--- a/ios/Classes/bridge_generated.h
+++ b/ios/Classes/bridge_generated.h
@@ -34,6 +34,8 @@ typedef struct wire_Tag {
   struct wire_uint_8_list *genre;
   uint32_t *track_number;
   uint32_t *track_total;
+  uint32_t *disc_number;
+  uint32_t *disc_total;
   uint32_t *duration;
   struct wire_list_picture *pictures;
 } wire_Tag;

--- a/lib/src/bridge_definitions.dart
+++ b/lib/src/bridge_definitions.dart
@@ -114,6 +114,12 @@ class Tag {
   /// The total amount of songs in a list.
   final int? trackTotal;
 
+  /// The position of the disc in a list.
+  final int? discNumber;
+
+  /// The total amount of discs in a list.
+  final int? discTotal;
+
   /// The duration of the song. Setting this field
   /// when writing will do nothing.
   final int? duration;
@@ -130,6 +136,8 @@ class Tag {
     this.genre,
     this.trackNumber,
     this.trackTotal,
+    this.discNumber,
+    this.discTotal,
     this.duration,
     required this.pictures,
   });

--- a/lib/src/bridge_definitions.dart
+++ b/lib/src/bridge_definitions.dart
@@ -94,10 +94,13 @@ class Tag {
   final String? title;
 
   /// The artist of the song.
-  final String? artist;
+  final String? trackArtist;
 
   /// The album the song is from.
   final String? album;
+
+  /// The artist of the album.
+  final String? albumArtist;
 
   /// The year that this song was made.
   final int? year;
@@ -120,8 +123,9 @@ class Tag {
 
   const Tag({
     this.title,
-    this.artist,
+    this.trackArtist,
     this.album,
+    this.albumArtist,
     this.year,
     this.genre,
     this.trackNumber,

--- a/lib/src/bridge_generated.dart
+++ b/lib/src/bridge_generated.dart
@@ -132,18 +132,19 @@ class AudiotagsImpl implements Audiotags {
 
   Tag _wire2api_tag(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 9)
-      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 10)
+      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
     return Tag(
       title: _wire2api_opt_String(arr[0]),
-      artist: _wire2api_opt_String(arr[1]),
+      trackArtist: _wire2api_opt_String(arr[1]),
       album: _wire2api_opt_String(arr[2]),
-      year: _wire2api_opt_box_autoadd_u32(arr[3]),
-      genre: _wire2api_opt_String(arr[4]),
-      trackNumber: _wire2api_opt_box_autoadd_u32(arr[5]),
-      trackTotal: _wire2api_opt_box_autoadd_u32(arr[6]),
-      duration: _wire2api_opt_box_autoadd_u32(arr[7]),
-      pictures: _wire2api_list_picture(arr[8]),
+      albumArtist: _wire2api_opt_String(arr[3]),
+      year: _wire2api_opt_box_autoadd_u32(arr[4]),
+      genre: _wire2api_opt_String(arr[5]),
+      trackNumber: _wire2api_opt_box_autoadd_u32(arr[6]),
+      trackTotal: _wire2api_opt_box_autoadd_u32(arr[7]),
+      duration: _wire2api_opt_box_autoadd_u32(arr[8]),
+      pictures: _wire2api_list_picture(arr[9]),
     );
   }
 
@@ -257,8 +258,9 @@ class AudiotagsPlatform extends FlutterRustBridgeBase<AudiotagsWire> {
 
   void _api_fill_to_wire_tag(Tag apiObj, wire_Tag wireObj) {
     wireObj.title = api2wire_opt_String(apiObj.title);
-    wireObj.artist = api2wire_opt_String(apiObj.artist);
+    wireObj.track_artist = api2wire_opt_String(apiObj.trackArtist);
     wireObj.album = api2wire_opt_String(apiObj.album);
+    wireObj.album_artist = api2wire_opt_String(apiObj.albumArtist);
     wireObj.year = api2wire_opt_box_autoadd_u32(apiObj.year);
     wireObj.genre = api2wire_opt_String(apiObj.genre);
     wireObj.track_number = api2wire_opt_box_autoadd_u32(apiObj.trackNumber);
@@ -499,9 +501,11 @@ final class wire_list_picture extends ffi.Struct {
 final class wire_Tag extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> title;
 
-  external ffi.Pointer<wire_uint_8_list> artist;
+  external ffi.Pointer<wire_uint_8_list> track_artist;
 
   external ffi.Pointer<wire_uint_8_list> album;
+
+  external ffi.Pointer<wire_uint_8_list> album_artist;
 
   external ffi.Pointer<ffi.Uint32> year;
 

--- a/lib/src/bridge_generated.dart
+++ b/lib/src/bridge_generated.dart
@@ -132,8 +132,8 @@ class AudiotagsImpl implements Audiotags {
 
   Tag _wire2api_tag(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 10)
-      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
+    if (arr.length != 12)
+      throw Exception('unexpected arr length: expect 12 but see ${arr.length}');
     return Tag(
       title: _wire2api_opt_String(arr[0]),
       trackArtist: _wire2api_opt_String(arr[1]),
@@ -143,8 +143,10 @@ class AudiotagsImpl implements Audiotags {
       genre: _wire2api_opt_String(arr[5]),
       trackNumber: _wire2api_opt_box_autoadd_u32(arr[6]),
       trackTotal: _wire2api_opt_box_autoadd_u32(arr[7]),
-      duration: _wire2api_opt_box_autoadd_u32(arr[8]),
-      pictures: _wire2api_list_picture(arr[9]),
+      discNumber: _wire2api_opt_box_autoadd_u32(arr[8]),
+      discTotal: _wire2api_opt_box_autoadd_u32(arr[9]),
+      duration: _wire2api_opt_box_autoadd_u32(arr[10]),
+      pictures: _wire2api_list_picture(arr[11]),
     );
   }
 
@@ -265,6 +267,8 @@ class AudiotagsPlatform extends FlutterRustBridgeBase<AudiotagsWire> {
     wireObj.genre = api2wire_opt_String(apiObj.genre);
     wireObj.track_number = api2wire_opt_box_autoadd_u32(apiObj.trackNumber);
     wireObj.track_total = api2wire_opt_box_autoadd_u32(apiObj.trackTotal);
+    wireObj.disc_number = api2wire_opt_box_autoadd_u32(apiObj.discNumber);
+    wireObj.disc_total = api2wire_opt_box_autoadd_u32(apiObj.discTotal);
     wireObj.duration = api2wire_opt_box_autoadd_u32(apiObj.duration);
     wireObj.pictures = api2wire_list_picture(apiObj.pictures);
   }
@@ -514,6 +518,10 @@ final class wire_Tag extends ffi.Struct {
   external ffi.Pointer<ffi.Uint32> track_number;
 
   external ffi.Pointer<ffi.Uint32> track_total;
+
+  external ffi.Pointer<ffi.Uint32> disc_number;
+
+  external ffi.Pointer<ffi.Uint32> disc_total;
 
   external ffi.Pointer<ffi.Uint32> duration;
 

--- a/macos/Classes/bridge_generated.h
+++ b/macos/Classes/bridge_generated.h
@@ -27,8 +27,9 @@ typedef struct wire_list_picture {
 
 typedef struct wire_Tag {
   struct wire_uint_8_list *title;
-  struct wire_uint_8_list *artist;
+  struct wire_uint_8_list *track_artist;
   struct wire_uint_8_list *album;
+  struct wire_uint_8_list *album_artist;
   uint32_t *year;
   struct wire_uint_8_list *genre;
   uint32_t *track_number;

--- a/macos/Classes/bridge_generated.h
+++ b/macos/Classes/bridge_generated.h
@@ -34,6 +34,8 @@ typedef struct wire_Tag {
   struct wire_uint_8_list *genre;
   uint32_t *track_number;
   uint32_t *track_total;
+  uint32_t *disc_number;
+  uint32_t *disc_total;
   uint32_t *duration;
   struct wire_list_picture *pictures;
 } wire_Tag;

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -87,6 +87,16 @@ pub fn write(path: String, data: Tag) -> Result<(), AudioTagsError> {
     if let Some(track_total) = data.track_total {
         tag.set_track_total(track_total);
     }
+    
+    // Disc number
+    if let Some(disc_number) = data.disc_number {
+        tag.set_disk(disc_number);
+    }
+
+    // Disc total
+    if let Some(disc_total) = data.disc_total {
+        tag.set_disk_total(disc_total);
+    }
 
     // Genre
     if let Some(genre) = data.genre {

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -58,14 +58,19 @@ pub fn write(path: String, data: Tag) -> Result<(), AudioTagsError> {
         tag.insert_text(ItemKey::TrackTitle, title);
     }
 
-    // Artist
-    if let Some(artist) = data.artist {
-        tag.insert_text(ItemKey::TrackArtist, artist);
+    // Track Artist
+    if let Some(track_artist) = data.track_artist {
+        tag.insert_text(ItemKey::TrackArtist, track_artist);
     }
 
     // Album Title
     if let Some(album) = data.album {
         tag.insert_text(ItemKey::AlbumTitle, album);
+    }
+
+    // Album Artist
+    if let Some(album_artist) = data.album_artist {
+        tag.insert_text(ItemKey::AlbumArtist, album_artist);
     }
 
     // Year

--- a/rust/src/bridge_generated.io.rs
+++ b/rust/src/bridge_generated.io.rs
@@ -87,8 +87,9 @@ impl Wire2Api<Tag> for wire_Tag {
     fn wire2api(self) -> Tag {
         Tag {
             title: self.title.wire2api(),
-            artist: self.artist.wire2api(),
+            track_artist: self.track_artist.wire2api(),
             album: self.album.wire2api(),
+            album_artist: self.album_artist.wire2api(),
             year: self.year.wire2api(),
             genre: self.genre.wire2api(),
             track_number: self.track_number.wire2api(),
@@ -128,8 +129,9 @@ pub struct wire_Picture {
 #[derive(Clone)]
 pub struct wire_Tag {
     title: *mut wire_uint_8_list,
-    artist: *mut wire_uint_8_list,
+    track_artist: *mut wire_uint_8_list,
     album: *mut wire_uint_8_list,
+    album_artist: *mut wire_uint_8_list,
     year: *mut u32,
     genre: *mut wire_uint_8_list,
     track_number: *mut u32,
@@ -177,8 +179,9 @@ impl NewWithNullPtr for wire_Tag {
     fn new_with_null_ptr() -> Self {
         Self {
             title: core::ptr::null_mut(),
-            artist: core::ptr::null_mut(),
+            track_artist: core::ptr::null_mut(),
             album: core::ptr::null_mut(),
+            album_artist: core::ptr::null_mut(),
             year: core::ptr::null_mut(),
             genre: core::ptr::null_mut(),
             track_number: core::ptr::null_mut(),

--- a/rust/src/bridge_generated.io.rs
+++ b/rust/src/bridge_generated.io.rs
@@ -94,6 +94,8 @@ impl Wire2Api<Tag> for wire_Tag {
             genre: self.genre.wire2api(),
             track_number: self.track_number.wire2api(),
             track_total: self.track_total.wire2api(),
+            disc_number: self.disc_number.wire2api(),
+            disc_total: self.disc_total.wire2api(),
             duration: self.duration.wire2api(),
             pictures: self.pictures.wire2api(),
         }
@@ -136,6 +138,8 @@ pub struct wire_Tag {
     genre: *mut wire_uint_8_list,
     track_number: *mut u32,
     track_total: *mut u32,
+    disc_number: *mut u32,
+    disc_total: *mut u32,
     duration: *mut u32,
     pictures: *mut wire_list_picture,
 }
@@ -186,6 +190,8 @@ impl NewWithNullPtr for wire_Tag {
             genre: core::ptr::null_mut(),
             track_number: core::ptr::null_mut(),
             track_total: core::ptr::null_mut(),
+            disc_number: core::ptr::null_mut(),
+            disc_total: core::ptr::null_mut(),
             duration: core::ptr::null_mut(),
             pictures: core::ptr::null_mut(),
         }

--- a/rust/src/bridge_generated.rs
+++ b/rust/src/bridge_generated.rs
@@ -245,6 +245,8 @@ impl support::IntoDart for Tag {
             self.genre.into_dart(),
             self.track_number.into_dart(),
             self.track_total.into_dart(),
+            self.disc_number.into_dart(),
+            self.disc_total.into_dart(),
             self.duration.into_dart(),
             self.pictures.into_into_dart().into_dart(),
         ]

--- a/rust/src/bridge_generated.rs
+++ b/rust/src/bridge_generated.rs
@@ -238,8 +238,9 @@ impl support::IntoDart for Tag {
     fn into_dart(self) -> support::DartAbi {
         vec![
             self.title.into_dart(),
-            self.artist.into_dart(),
+            self.track_artist.into_dart(),
             self.album.into_dart(),
+            self.album_artist.into_dart(),
             self.year.into_dart(),
             self.genre.into_dart(),
             self.track_number.into_dart(),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,7 +25,7 @@ mod tests {
         println!("{:?}", tag.track_number);
         println!("{:?}", tag.track_total);
         println!("{:?}", tag.disc_number);
-        println!("{:?}", tag.dsic_total);
+        println!("{:?}", tag.disc_total);
         println!("{:?}", tag.genre);
         println!("{:?}", tag.duration);
         println!("{:?}", tag.pictures);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -18,8 +18,9 @@ mod tests {
         let tag = read("samples/test.mp3".to_string()).context("Could not read tag.")?;
 
         println!("{:?}", tag.title);
-        println!("{:?}", tag.artist);
+        println!("{:?}", tag.track_artist);
         println!("{:?}", tag.album);
+        println!("{:?}", tag.album_artist);
         println!("{:?}", tag.year);
         println!("{:?}", tag.track_number);
         println!("{:?}", tag.track_total);
@@ -36,8 +37,9 @@ mod tests {
             "samples/test.mp3".to_string(),
             Tag {
                 title: None,
-                artist: None,
+                track_artist: None,
                 album: None,
+                album_artist: None,
                 year: None,
                 genre: None,
                 track_number: None,
@@ -77,8 +79,9 @@ mod tests {
             "samples/test.mp3".to_string(),
             Tag {
                 title: Some("Title".to_string()),
-                artist: Some("Artist".to_string()),
+                track_artist: Some("Track Artist".to_string()),
                 album: Some("Album".to_string()),
+                album_artist: Some("Album Artist".to_string()),
                 year: Some(2022),
                 track_number: Some(1),
                 track_total: Some(2),
@@ -96,8 +99,9 @@ mod tests {
         let tag = read("samples/test.mp4".to_string()).context("Could not read tag.")?;
 
         println!("{:?}", tag.title);
-        println!("{:?}", tag.artist);
+        println!("{:?}", tag.track_artist);
         println!("{:?}", tag.album);
+        println!("{:?}", tag.album_artist);
         println!("{:?}", tag.year);
         println!("{:?}", tag.track_number);
         println!("{:?}", tag.track_total);
@@ -114,8 +118,9 @@ mod tests {
             "samples/test.mp4".to_string(),
             Tag {
                 title: None,
-                artist: None,
+                track_artist: None,
                 album: None,
+                album_artist: None,
                 year: None,
                 genre: None,
                 track_number: None,
@@ -155,8 +160,9 @@ mod tests {
             "samples/test.mp4".to_string(),
             Tag {
                 title: Some("Title".to_string()),
-                artist: Some("Artist".to_string()),
+                track_artist: Some("Track Artist".to_string()),
                 album: Some("Album".to_string()),
+                album_artist: Some("Album Artist".to_string()),
                 year: Some(2022),
                 track_number: Some(1),
                 track_total: Some(2),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,6 +24,8 @@ mod tests {
         println!("{:?}", tag.year);
         println!("{:?}", tag.track_number);
         println!("{:?}", tag.track_total);
+        println!("{:?}", tag.disc_number);
+        println!("{:?}", tag.dsic_total);
         println!("{:?}", tag.genre);
         println!("{:?}", tag.duration);
         println!("{:?}", tag.pictures);
@@ -44,6 +46,8 @@ mod tests {
                 genre: None,
                 track_number: None,
                 track_total: None,
+                disc_number: None,
+                disc_total: None,
                 duration: None,
                 pictures: Vec::new(),
             },
@@ -85,6 +89,8 @@ mod tests {
                 year: Some(2022),
                 track_number: Some(1),
                 track_total: Some(2),
+                disc_number: Some(1),
+                disc_total: Some(3),
                 genre: Some("Genre".to_string()),
                 pictures: vec![picture1, picture2],
                 ..Default::default()
@@ -105,6 +111,8 @@ mod tests {
         println!("{:?}", tag.year);
         println!("{:?}", tag.track_number);
         println!("{:?}", tag.track_total);
+        println!("{:?}", tag.disc_number);
+        println!("{:?}", tag.disc_total);
         println!("{:?}", tag.genre);
         println!("{:?}", tag.duration);
         println!("{:?}", tag.pictures);
@@ -125,6 +133,8 @@ mod tests {
                 genre: None,
                 track_number: None,
                 track_total: None,
+                disc_number: None,
+                disc_total: None,
                 duration: None,
                 pictures: Vec::new(),
             },
@@ -166,6 +176,8 @@ mod tests {
                 year: Some(2022),
                 track_number: Some(1),
                 track_total: Some(2),
+                disc_number: Some(1),
+                disc_total: Some(3),
                 genre: Some("Genre".to_string()),
                 pictures: vec![picture1, picture2],
                 ..Default::default()

--- a/rust/src/tag.rs
+++ b/rust/src/tag.rs
@@ -8,9 +8,11 @@ pub struct Tag {
     /// The title of the song.
     pub title: Option<String>,
     /// The artist of the song.
-    pub artist: Option<String>,
+    pub track_artist: Option<String>,
     /// The album the song is from.
     pub album: Option<String>,
+    /// The artist of the album.
+    pub album_artist: Option<String>,
     /// The year that this song was made.
     pub year: Option<u32>,
     /// The genre of the song.
@@ -30,8 +32,9 @@ impl Tag {
     /// Returns `true` if the tag has no data.
     pub fn is_empty(&self) -> bool {
         self.title.is_none()
-            && self.artist.is_none()
+            && self.track_artist.is_none()
             && self.album.is_none()
+            && self.album_artist.is_none()
             && self.year.is_none()
             && self.genre.is_none()
             && self.track_number.is_none()
@@ -57,8 +60,9 @@ impl From<&lofty::Tag> for Tag {
 
         Tag {
             title: tag.get_string(&ItemKey::TrackTitle).map(|e| e.to_string()),
-            artist: tag.get_string(&ItemKey::TrackArtist).map(|e| e.to_string()),
+            track_artist: tag.get_string(&ItemKey::TrackArtist).map(|e| e.to_string()),
             album: tag.get_string(&ItemKey::AlbumTitle).map(|e| e.to_string()),
+            album_artist: tag.get_string(&ItemKey::AlbumArtist).map(|e| e.to_string()),
             year: tag.year(),
             genre: tag.get_string(&ItemKey::Genre).map(|e| e.to_string()),
             track_number: tag.track(),

--- a/rust/src/tag.rs
+++ b/rust/src/tag.rs
@@ -21,6 +21,10 @@ pub struct Tag {
     pub track_number: Option<u32>,
     /// The total amount of songs in a list.
     pub track_total: Option<u32>,
+    /// The position of the disc in a list.
+    pub disc_number: Option<u32>,
+    /// The total amount of discs in a list.
+    pub disc_total: Option<u32>,
     /// The duration of the song. Setting this field
     /// when writing will do nothing.
     pub duration: Option<u32>,
@@ -39,6 +43,8 @@ impl Tag {
             && self.genre.is_none()
             && self.track_number.is_none()
             && self.track_total.is_none()
+            && self.disc_number.is_none()
+            && self.disc_total.is_none()
             && self.duration.is_none()
             && self.pictures.is_empty()
     }
@@ -67,6 +73,8 @@ impl From<&lofty::Tag> for Tag {
             genre: tag.get_string(&ItemKey::Genre).map(|e| e.to_string()),
             track_number: tag.track(),
             track_total: tag.track_total(),
+            disc_number: tag.disk(),
+            disc_total: tag.disk_total(),
             pictures,
             duration: None,
         }


### PR DESCRIPTION
Added support for the following fields (dart field names):

* `albumArtist`
* `discNumber`
* `discTotal`

Changed fields:

* `artist` > `trackArtist`