### PR TITLE
Update Lofty-rs dependency

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 flutter_rust_bridge = "=1.82.1"
-lofty = "0.16.0"
+lofty = "0.18.2"
 
 [dev-dependencies]
 anyhow = "1.0.68"


### PR DESCRIPTION
- Update lofty-rs to version 0.18.2.
- Fixes #13

The issue: "[Bug] Abnormally large amount of data was provided" was a lofty issue, not an issue with the audiotags plugin.
We were on v0.16.0 of lofty-rs and there have been numerous fixes to that library since. v0.18.2 fixes the aforementioned issue, along with a slew of other fixes.
