### PR TITLE
fix(android build): fixing the "namespace missing" android build error related to issue #19

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace = "com.erikas.audiotags"
     compileSdkVersion 31
 
     compileOptions {
@@ -42,7 +43,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
     }
 
     externalNativeBuild {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace = "com.erikas.audiotags"
+    // Conditional for compatibility with AGP < 4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.erikas.audiotags'
+    }
+
     compileSdkVersion 31
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.erikas.audiotags">
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.erikas.audiotags">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Added the `namespace` "com.erikas.audiotags" to `build.gradle`, removed the package property from `AndroidManifest.xml` and changed `minSdkVersion` to 21 to fix the "namespace missing" compile error and to meet Google's new requirements for Android in new versions of Gradle and AGP.

BREAKING CHANGE: Android sdk minimum version updated from 16 to 21 
Closes #19