### PR TITLE
Delete macos.zip after extracting

### DIFF
--- a/macos/audiotags.podspec
+++ b/macos/audiotags.podspec
@@ -9,6 +9,7 @@ if [ ! -f macos.zip ]
 then
   curl -L "#{lib_url}" -o macos.zip
   unzip macos.zip
+  rm macos.zip
 fi
 cd ..
 `


### PR DESCRIPTION
Fix `ld: library 'macos' not found` error during a build for macos